### PR TITLE
Dev/genomecomparison

### DIFF
--- a/genomecomparison.h
+++ b/genomecomparison.h
@@ -28,6 +28,7 @@ private slots:
     bool deleteGenome();
     bool compareGenomes();
     void setAuto(bool toggle);
+    void updateGenomeName(int row, int col);
 
 private:
     //---- Styling


### PR DESCRIPTION
- Updated Styling on buttons (test)
- Genome name editing via genome table now working
- Tooltips for RGB colour values
- Manual comparison now set to compare the newer genome with older genome (same as Auto Compare in main genome window)
- Signal blocking of tables on row insert. Stopping 70+ signals being sent every insert.
