### PR TITLE
Made it so logging turns on tracking

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -459,6 +459,8 @@ void MainWindow::RunSetUp()
     ui->actionPause_Sim->setEnabled(true);
     pauseButton->setEnabled(true);
 
+    if(ui->actionWrite_phylogeny->isChecked()||ui->actionSpecies_logging->isChecked())ui->actionPhylogeny_metrics->setChecked(true);
+
     //Reseed or reset
     ui->actionReset->setEnabled(false);
     resetButton->setEnabled(false);


### PR DESCRIPTION
Minor change but now if you run it with species tracking on, it'll turn on the phylogeny_metrics tracking.